### PR TITLE
fix(item): add a default image url

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
+import { DEFAULT_ITEM_IMAGE_URL } from "../constants/default_item_image";
 
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || DEFAULT_ITEM_IMAGE_URL}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/constants/default_item_image.js
+++ b/frontend/src/constants/default_item_image.js
@@ -1,1 +1,1 @@
-export const DEFAULT_ITEM_IMAGE_URL = '/placeholder.png'
+export const DEFAULT_ITEM_IMAGE_URL = "/placeholder.png";

--- a/frontend/src/constants/default_item_image.js
+++ b/frontend/src/constants/default_item_image.js
@@ -1,0 +1,1 @@
+export const DEFAULT_ITEM_IMAGE_URL = '/placeholder.png'


### PR DESCRIPTION
in order to not force users to have to upload when creating a new item, adding a default image to the Item model is the best solution.

Providing a value for the image preview in the component when an image is not on the item itself allows us to always have an image to display, while at the same time not taking up space in the database. As well as if we change our mind on the default image's url in the future, it's a 1 line change instead of a database update.

#INC-5312: Missing image
Fixes https://github.com/ObelusFamily/Anythink-Market-3yia1/issues/2

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
