### PR TITLE
fix(item): add a default image url

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -2,6 +2,7 @@ var mongoose = require("mongoose");
 var uniqueValidator = require("mongoose-unique-validator");
 var slug = require("slug");
 var User = mongoose.model("User");
+var DEFAULT_ITEM_IMAGE_URL = "/placeholder.png"; // Keep an eye on the default image in the front end too. frontend/src/constants/default_item_image.js -- ideally we'd be able to localize this to a single place, but our backend and frontend can't share code yet.
 
 var ItemSchema = new mongoose.Schema(
   {
@@ -49,7 +50,7 @@ ItemSchema.methods.toJSONFor = function(user) {
     slug: this.slug,
     title: this.title,
     description: this.description,
-    image: this.image,
+    image: this.image || DEFAULT_ITEM_IMAGE_URL,
     createdAt: this.createdAt,
     updatedAt: this.updatedAt,
     tagList: this.tagList,


### PR DESCRIPTION
in order to not force users to have to upload when creating a new item, adding a default image to the Item model is the best solution.

Providing a value for the image when serializing the Item model to json from the backend when an image is not on the item itself allows us to always have a value, while at the same time not taking up space in the database. As well as if we change our mind on the default image's url in the future, it's a 1 line change instead of a database update.

#INC-5312: Missing image #3
Fixes #4

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
