### PR TITLE
feat(items): add filtering by title

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "jsonwebtoken": "7.1.9",
     "method-override": "2.3.5",
     "methods": "1.1.2",
+    "mongo-sanitize": "^1.1.0",
     "mongoose": "5.12.5",
     "mongoose-unique-validator": "3.0.0",
     "morgan": "1.7.0",

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -1,5 +1,6 @@
 var router = require("express").Router();
 var mongoose = require("mongoose");
+var sanitize = require("mongo-sanitize");
 var Item = mongoose.model("Item");
 var Comment = mongoose.model("Comment");
 var User = mongoose.model("User");
@@ -51,6 +52,10 @@ router.get("/", auth.optional, function(req, res, next) {
 
   if (typeof req.query.tag !== "undefined") {
     query.tagList = { $in: [req.query.tag] };
+  }
+
+  if (typeof req.query.title !== "undefined") {
+    query.title = { $regex: sanitize(req.query.title), $options : 'i' }
   }
 
   Promise.all([

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2143,6 +2143,11 @@ moment@2.x.x:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+mongo-sanitize@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mongo-sanitize/-/mongo-sanitize-1.1.0.tgz#01346b55f90716a42de3a1f957500a11c0752c36"
+  integrity sha512-6gB9AiJD+om2eZLxaPKIP5Q8P3Fr+s+17rVWso7hU0+MAzmIvIMlgTYuyvalDLTtE/p0gczcvJ8A3pbN1XmQ/A==
+
 mongodb@3.6.6:
   version "3.6.6"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.6.tgz#92e3658f45424c34add3003e3046c1535c534449"


### PR DESCRIPTION
- add regex mongo querying using the query param `"title"` w/ the `$regex` mongo search option
- add case insenstive search using the `$option: 'i'` for mongo's regex
- santize the user input in the query since we're passing it right to the mongo engine

Add product filtering support to our API
Fixes #6

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
